### PR TITLE
cleaning wires:url

### DIFF
--- a/system/expressionengine/third_party/wires/mod.wires.php
+++ b/system/expressionengine/third_party/wires/mod.wires.php
@@ -279,6 +279,9 @@ class Wires {
 			}
 		}
 
+		// cleanup the query string, removing any empty arguments
+		$url = $this->_cleanup_url($url);
+
 		return $url;
 	}
 	


### PR DESCRIPTION
The URL generated by `exp:wires:url` needs to have the unused query strings removed too
